### PR TITLE
.spectate - push to spectators rather than players

### DIFF
--- a/Commands/spectate_eligible.js
+++ b/Commands/spectate_eligible.js
@@ -14,10 +14,15 @@ module.exports.run = async (bot, game, message, args) => {
         if (message.author.id === game.players[i].id)
             return message.reply("You are already playing.");
     }
+
+    for (let i = 0; i < game.spectators.length; i++)
+        if (message.author.id === game.spectators[i].id)
+            return message.reply("You are already spectating");
+            
     if (game.canJoin) return message.reply("You cannot spectate the game yet. Try this command again when the timer runs out.");
 
     const member = await game.guild.members.fetch(message.author.id);
-    game.players.push({ id: message.author.id, member: member, name: member.displayName });
+    game.spectators.push({ id: message.author.id, member: member, name: member.displayName });
     member.roles.add(settings.spectatorRole);
     message.channel.send(`<@${message.author.id}> began spectating the game!`);
 


### PR DESCRIPTION
Hello!
I noticed last game that the bot did not remove spectators. 
I believe it's because the spectate command never assigned players to be spectators and instead assigned them as players. Thus never removed the role when ending the game.
This quick fix should make it so that they'll be added to spectator. From what I've seen it shouldn't break anything haha.
Shoot me a note if this doesn't look good.

Thank you!